### PR TITLE
Fix formatting and typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,17 +49,18 @@ Next, you must load the service provider:
 2. Click the `Create a Bot User` button on your Discord application.
 3. Paste your bot's API token, found under `App Bot User`, in your `services.php` config file:
 
-```php
-// config/services.php
-'discord' => [
-    'token' => 'YOUR_API_TOKEN',
-],```
+    ```php
+    // config/services.php
+    'discord' => [
+        'token' => 'YOUR_API_TOKEN',
+    ],
+    ```
 
 4. Add the bot to your server and identify it by running the artisan command:
 
-``shell
-php artisan discord:setup
-```
+    ```shell
+    php artisan discord:setup
+    ```
 
 ## Usage
 
@@ -110,7 +111,7 @@ You may now tell Laravel to send notifications to Discord channels in the `via` 
 ```php
 class GameChallengeNotification extends Notification
 {
-    public $channelger;
+    public $challenger;
 
     public $game;
 
@@ -119,6 +120,7 @@ class GameChallengeNotification extends Notification
         $this->challenger = $challenger;
         $this->game = $game;
     }
+
     public function via($notifiable)
     {
         return [DiscordChannel::class];
@@ -126,7 +128,7 @@ class GameChallengeNotification extends Notification
 
     public function toDiscord($notifiable)
     {
-        return DiscordMessage::create("You have been challenged to a game of *{$this->game->name}* by **{$this->channelger->name}**!");
+        return DiscordMessage::create("You have been challenged to a game of *{$this->game->name}* by **{$this->challenger->name}**!");
     }
 }
 ```

--- a/src/Commands/SetupCommand.php
+++ b/src/Commands/SetupCommand.php
@@ -28,7 +28,7 @@ class SetupCommand extends Command
             $this->warn('Add the bot to your server by visiting this link: https://discordapp.com/oauth2/authorize?&client_id='.$clientId.'&scope=bot&permissions=0');
         }
 
-        $this->warn("Attempting to identify the bot with Discord's WebScoket gateway...");
+        $this->warn("Attempting to identify the bot with Discord's websocket gateway...");
 
         $gateway = 'wss://gateway.discord.gg';
 
@@ -41,14 +41,14 @@ class SetupCommand extends Command
 
             $gateway = Arr::get(json_decode($response->getBody(), true), 'url', $gateway);
         } catch (\Excetion $e) {
-            $this->warn("Could not get a WebSocket gateway address, defaulting to {$gateway}.");
+            $this->warn("Could not get a websocket gateway address, defaulting to {$gateway}.");
         }
 
         $this->warn("Connecting to '$gateway'...");
 
         $client = new Client($gateway);
 
-        // Discord requires all bots to connect via a WebSocket connection and
+        // Discord requires all bots to connect via a websocket connection and
         // identify at least once before any HTTP API requests are allowed.
         // https://discordapp.com/developers/docs/topics/gateway#gateway-identify
         $client->send(json_encode([


### PR DESCRIPTION
Code blocks nested in an ordered list need to be indented for the list to keep its current item count. Removing the indentation will reset the list item number back to 1 after each unindented break in the list.