### PR TITLE
Add support for embedded objects

### DIFF
--- a/src/DiscordChannel.php
+++ b/src/DiscordChannel.php
@@ -39,6 +39,7 @@ class DiscordChannel
 
         $this->discord->send($channel, [
             'content' => $message->body,
+            'embed' => $message->embed,
         ]);
     }
 }

--- a/src/DiscordMessage.php
+++ b/src/DiscordMessage.php
@@ -12,7 +12,7 @@ class DiscordMessage
     public $body;
 
     /**
-     * The embedded object attached to the message
+     * The embedded object attached to the message.
      *
      * @var array
      */
@@ -54,7 +54,7 @@ class DiscordMessage
     }
 
     /**
-     * Set the embedded object
+     * Set the embedded object.
      *
      * @param $embed
      *

--- a/src/DiscordMessage.php
+++ b/src/DiscordMessage.php
@@ -12,21 +12,31 @@ class DiscordMessage
     public $body;
 
     /**
-     * @param string $body
+     * The embedded object attached to the message
+     *
+     * @var array
+     */
+    public $embed;
+
+    /**
+     * @param string     $body
+     * @param array|null $embed
      *
      * @return static
      */
-    public static function create($body = '')
+    public static function create($body = '', $embed = [])
     {
         return new static($body);
     }
 
     /**
      * @param string $body
+     * @param array  $embed
      */
-    public function __construct($body = '')
+    public function __construct($body = '', $embed = [])
     {
         $this->body = $body;
+        $this->embed = $embed;
     }
 
     /**
@@ -39,6 +49,20 @@ class DiscordMessage
     public function body($body)
     {
         $this->body = $body;
+
+        return $this;
+    }
+
+    /**
+     * Set the embedded object
+     *
+     * @param $embed
+     *
+     * @return $this
+     */
+    public function embed($embed)
+    {
+        $this->embed = $embed;
 
         return $this;
     }

--- a/tests/DiscordChannelTest.php
+++ b/tests/DiscordChannelTest.php
@@ -23,7 +23,7 @@ class DiscordChannelTest extends \PHPUnit_Framework_TestCase
                 ],
                 'json' => ['content' => 'Hello, Discord!', 'embed' => [
                     'title' => 'Object Title',
-                    'url' => 'https://discordapp.com'
+                    'url' => 'https://discordapp.com',
                 ]],
             ])
             ->andReturn(new Response(200));

--- a/tests/DiscordChannelTest.php
+++ b/tests/DiscordChannelTest.php
@@ -21,7 +21,10 @@ class DiscordChannelTest extends \PHPUnit_Framework_TestCase
                 'headers' => [
                     'Authorization' => 'Bot super-secret',
                 ],
-                'json' => ['content' => 'Hello, Discord!'],
+                'json' => ['content' => 'Hello, Discord!', 'embed' => [
+                    'title' => 'Object Title',
+                    'url' => 'https://discordapp.com'
+                ]]
             ])
             ->andReturn(new Response(200));
 
@@ -63,6 +66,10 @@ class TestNotification extends \Illuminate\Notifications\Notification
     public function toDiscord()
     {
         return (new DiscordMessage)
-            ->body('Hello, Discord!');
+            ->body('Hello, Discord!')
+            ->embed([
+                'title' => 'Object Title',
+                'url' => 'https://discordapp.com'
+            ]);
     }
 }

--- a/tests/DiscordChannelTest.php
+++ b/tests/DiscordChannelTest.php
@@ -24,7 +24,7 @@ class DiscordChannelTest extends \PHPUnit_Framework_TestCase
                 'json' => ['content' => 'Hello, Discord!', 'embed' => [
                     'title' => 'Object Title',
                     'url' => 'https://discordapp.com'
-                ]]
+                ]],
             ])
             ->andReturn(new Response(200));
 
@@ -69,7 +69,7 @@ class TestNotification extends \Illuminate\Notifications\Notification
             ->body('Hello, Discord!')
             ->embed([
                 'title' => 'Object Title',
-                'url' => 'https://discordapp.com'
+                'url' => 'https://discordapp.com',
             ]);
     }
 }


### PR DESCRIPTION
This adds a second optional parameter when creating a Message to add an embedded object.

#7 Embedded Objects
https://discordapp.com/developers/docs/resources/channel#embed-object
