### PR TITLE
Send messages in log file if DISCORD_TOKEN is not specified

### DIFF
--- a/src/DiscordChannel.php
+++ b/src/DiscordChannel.php
@@ -3,6 +3,7 @@
 namespace NotificationChannels\Discord;
 
 use Illuminate\Notifications\Notification;
+use Log;
 
 class DiscordChannel
 {
@@ -37,6 +38,12 @@ class DiscordChannel
 
         $message = $notification->toDiscord($notifiable);
 
+        if (empty(config('services.discord.token'))) {
+            Log::debug("Message to discord channel №{$channel}.\nText: {$message->body}");
+
+            return;
+        }
+        
         return $this->discord->send($channel, [
             'content' => $message->body,
             'embed' => $message->embed,

--- a/src/DiscordChannel.php
+++ b/src/DiscordChannel.php
@@ -2,8 +2,8 @@
 
 namespace NotificationChannels\Discord;
 
-use Illuminate\Notifications\Notification;
 use Log;
+use Illuminate\Notifications\Notification;
 
 class DiscordChannel
 {
@@ -39,11 +39,11 @@ class DiscordChannel
         $message = $notification->toDiscord($notifiable);
 
         if (empty(config('services.discord.token'))) {
-            Log::debug("Message to discord channel №{$channel}.\nText: {$message->body}");
+            Log::debug("Message to discord channel №{$channel}.\nText:\n{$message->body}");
 
             return;
         }
-        
+
         return $this->discord->send($channel, [
             'content' => $message->body,
             'embed' => $message->embed,


### PR DESCRIPTION
I think what we do not want send messages to Discord channels while we in local development environment, i suggest send messages just in log file if DISCORD_TOKEN is not specified. 