### PR TITLE
Changed domain name for discord base api url

### DIFF
--- a/src/Discord.php
+++ b/src/Discord.php
@@ -15,7 +15,7 @@ class Discord
      *
      * @var string
      */
-    protected $baseUrl = 'https://discordapp.com/api';
+    protected $baseUrl = 'https://discord.com/api';
 
     /**
      * API HTTP client.


### PR DESCRIPTION
```
We’ve grown up. We are now Discord.com!
```

https://discord.com/developers/docs/reference says that the API url should now be `https://discord.com/api`.