### PR TITLE
Update composer dependency versions for Laravel 8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     "require": {
         "php": "^7.2",
         "ext-json": "*",
-        "guzzlehttp/guzzle": "^6.3",
+        "guzzlehttp/guzzle": "^6.3 || ^7.0.1",
         "illuminate/notifications": "^6.0 || ^7.0 || ^8.0",
         "illuminate/support": "^6.0 || ^7.0 || ^8.0",
         "illuminate/queue": "^6.0 || ^7.0 || ^8.0",
@@ -30,7 +30,7 @@
     "require-dev": {
         "mockery/mockery": "^1.3",
         "orchestra/testbench": "^5.0 || ^6.0",
-        "phpunit/phpunit": "^8.5"
+        "phpunit/phpunit": "^8.5 || ^9.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
As noted in the [Upgrade Guide](https://laravel.com/docs/8.x/upgrade) for Laravel 8, I've adjusted the composer.json file to allow support for the following:
* "phpunit/phpunit": "^8.5 || ^9.0" (^9.0 added)
* "guzzlehttp/guzzle": "^6.3 || ^7.0.1" (^7.0.1 added)

Without this present, the installation of this library will fail for Laravel 8.0 or newer versions.

**Error:**
```  Problem 1
    - Root composer.json requires laravel-notification-channels/discord dev-master -> satisfiable by laravel-notification-channels/discord[dev-master].
    - laravel-notification-channels/discord dev-master requires guzzlehttp/guzzle ^6.3 -> found guzzlehttp/guzzle[6.3.0, ..., 6.5.x-dev] but it conflicts with your root composer.json require (^7.0.1).```