### PR TITLE
Propagate the Discord API response exceptions

### DIFF
--- a/src/Discord.php
+++ b/src/Discord.php
@@ -90,7 +90,7 @@ class Discord
             ]);
         } catch (RequestException $exception) {
             if ($response = $exception->getResponse()) {
-                throw CouldNotSendNotification::serviceRespondedWithAnHttpError($response, 0, $exception);
+                throw CouldNotSendNotification::serviceRespondedWithAnHttpError($response, $response->getStatusCode(), $exception);
             }
 
             throw CouldNotSendNotification::serviceCommunicationError($exception);
@@ -101,7 +101,7 @@ class Discord
         $body = json_decode($response->getBody(), true);
 
         if (Arr::get($body, 'code', 0) > 0) {
-            throw CouldNotSendNotification::serviceRespondedWithAnApiError($body);
+            throw CouldNotSendNotification::serviceRespondedWithAnApiError($body, $body['code']);
         }
 
         return $body;

--- a/src/Discord.php
+++ b/src/Discord.php
@@ -3,9 +3,9 @@
 namespace NotificationChannels\Discord;
 
 use Exception;
-use Illuminate\Support\Arr;
 use GuzzleHttp\Client as HttpClient;
 use GuzzleHttp\Exception\RequestException;
+use Illuminate\Support\Arr;
 use NotificationChannels\Discord\Exceptions\CouldNotSendNotification;
 
 class Discord

--- a/src/Discord.php
+++ b/src/Discord.php
@@ -90,7 +90,7 @@ class Discord
             ]);
         } catch (RequestException $exception) {
             if ($response = $exception->getResponse()) {
-                throw CouldNotSendNotification::serviceRespondedWithAnHttpError($response);
+                throw CouldNotSendNotification::serviceRespondedWithAnHttpError($response, 0, $exception);
             }
 
             throw CouldNotSendNotification::serviceCommunicationError($exception);

--- a/src/Exceptions/CouldNotSendNotification.php
+++ b/src/Exceptions/CouldNotSendNotification.php
@@ -10,6 +10,8 @@ class CouldNotSendNotification extends Exception
 {
     /**
      * @param \Psr\Http\Message\ResponseInterface $response
+	 * @param int $code
+	 * @param \Exception $exception
      *
      * @return static
      */
@@ -26,12 +28,13 @@ class CouldNotSendNotification extends Exception
 
     /**
      * @param array $response
+	 * @param int $code
      *
      * @return static
      */
-    public static function serviceRespondedWithAnApiError(array $response)
+    public static function serviceRespondedWithAnApiError(array $response, $code, $exception)
     {
-        return new static("Discord responded with an API error: {$response['code']}: {$response['message']}");
+        return new static("Discord responded with an API error: {$response['code']}: {$response['message']}", $code);
     }
 
     /**
@@ -41,6 +44,6 @@ class CouldNotSendNotification extends Exception
      */
     public static function serviceCommunicationError(Exception $exception)
     {
-        return new static("Communication with Discord failed: {$exception->getCode()}: {$exception->getMessage()}");
+        return new static("Communication with Discord failed: {$exception->getCode()}: {$exception->getMessage()}", $exception->getCode(), $exception);
     }
 }

--- a/src/Exceptions/CouldNotSendNotification.php
+++ b/src/Exceptions/CouldNotSendNotification.php
@@ -10,8 +10,8 @@ class CouldNotSendNotification extends Exception
 {
     /**
      * @param \Psr\Http\Message\ResponseInterface $response
-	 * @param int $code
-	 * @param \Exception $exception
+     * @param int $code
+     * @param \Exception $exception
      *
      * @return static
      */
@@ -28,7 +28,7 @@ class CouldNotSendNotification extends Exception
 
     /**
      * @param array $response
-	 * @param int $code
+     * @param int $code
      *
      * @return static
      */

--- a/src/Exceptions/CouldNotSendNotification.php
+++ b/src/Exceptions/CouldNotSendNotification.php
@@ -13,7 +13,7 @@ class CouldNotSendNotification extends Exception
      *
      * @return static
      */
-    public static function serviceRespondedWithAnHttpError(ResponseInterface $response)
+    public static function serviceRespondedWithAnHttpError(ResponseInterface $response, $code, $exception)
     {
         $message = "Discord responded with an HTTP error: {$response->getStatusCode()}";
 
@@ -21,7 +21,7 @@ class CouldNotSendNotification extends Exception
             $message .= ": $error";
         }
 
-        return new static($message);
+        return new static($message, $code, $exception);
     }
 
     /**


### PR DESCRIPTION
Issue #41.
I apologize that I do not have tests for this code. I also used the tag v1.0.8 as I'm using Laravel 5.8 in my project and newer versions did not solve my composer dependencies. It should work with newer versions too, as the code seems identical.