### PR TITLE
fix: update Discord domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 [![Code Coverage](https://img.shields.io/scrutinizer/coverage/g/laravel-notification-channels/discord/master.svg?style=flat-square)](https://scrutinizer-ci.com/g/laravel-notification-channels/discord/?branch=master)
 [![Total Downloads](https://img.shields.io/packagist/dt/laravel-notification-channels/discord.svg?style=flat-square)](https://packagist.org/packages/laravel-notification-channels/discord)
 
-This package makes it easy to send notifications using the [Discord bot API](https://discordapp.com/developers/docs/intro) with Laravel.
+This package makes it easy to send notifications using the [Discord bot API](https://discord.com/developers/docs/intro) with Laravel.
 
 ## Contents
 
@@ -46,7 +46,7 @@ Next, you must load the service provider:
 
 ### Setting up your Discord bot
 
-1. [Create a Discord application.](https://discordapp.com/developers/applications/me/create)
+1. [Create a Discord application.](https://discord.com/developers/applications)
 2. Click the `Create a Bot User` button on your Discord application.
 3. Paste your bot's API token, found under `App Bot User`, in your `services.php` config file:
 
@@ -107,7 +107,7 @@ class Guild extends Eloquent
 > }
 > ```
 >
-> Please take note that the `getPrivateChannel` method only accepts [Discord's snowflake IDs](https://discordapp.com/developers/docs/reference#snowflakes). There is no API route provided by Discord to lookup a user's ID by their name and tag, and the process for copying and pasting a user ID can be confusing to some users. Because of this, it is recommended to add the option for users to connect their Discord account to their account within your application either by logging in with Discord or linking it to their pre-existing account.
+> Please take note that the `getPrivateChannel` method only accepts [Discord's snowflake IDs](https://discord.com/developers/docs/reference#snowflakes). There is no API route provided by Discord to lookup a user's ID by their name and tag, and the process for copying and pasting a user ID can be confusing to some users. Because of this, it is recommended to add the option for users to connect their Discord account to their account within your application either by logging in with Discord or linking it to their pre-existing account.
 
 You may now tell Laravel to send notifications to Discord channels in the `via` method:
 
@@ -142,8 +142,8 @@ class GameChallengeNotification extends Notification
 
 ### Available Message methods
 
-* `body(string)`: Set the content of the message. ([Supports basic markdown](https://support.discordapp.com/hc/en-us/articles/210298617-Markdown-Text-101-Chat-Formatting-Bold-Italic-Underline-))
-* `embed(array)`: Set the embedded content. ([View embed structure](https://discordapp.com/developers/docs/resources/channel#embed-object))
+* `body(string)`: Set the content of the message. ([Supports basic markdown](https://support.discord.com/hc/en-us/articles/210298617-Markdown-Text-101-Chat-Formatting-Bold-Italic-Underline-))
+* `embed(array)`: Set the embedded content. ([View embed structure](https://discord.com/developers/docs/resources/channel#embed-object))
 
 ## Changelog
 

--- a/src/Commands/SetupCommand.php
+++ b/src/Commands/SetupCommand.php
@@ -64,7 +64,7 @@ class SetupCommand extends Command
         if (! $this->confirm('Is the bot already added to your server?')) {
             $clientId = $this->ask('What is your Discord app client ID?');
 
-            $this->warn('Add the bot to your server by visiting this link: https://discordapp.com/oauth2/authorize?&client_id='.$clientId.'&scope=bot&permissions=0');
+            $this->warn('Add the bot to your server by visiting this link: https://discord.com/oauth2/authorize?&client_id='.$clientId.'&scope=bot&permissions=0');
 
             if (! $this->confirm('Continue?', true)) {
                 return -1;
@@ -81,7 +81,7 @@ class SetupCommand extends Command
 
         // Discord requires all bots to connect via a websocket connection and
         // identify at least once before any API requests over HTTP are allowed.
-        // https://discordapp.com/developers/docs/topics/gateway#gateway-identify
+        // https://discord.com/developers/docs/topics/gateway#gateway-identify
         $client->send(json_encode([
             'op' => 2,
             'd' => [
@@ -128,7 +128,7 @@ class SetupCommand extends Command
         $gateway = $this->gateway;
 
         try {
-            $response = $this->guzzle->get('https://discordapp.com/api/gateway');
+            $response = $this->guzzle->get('https://discord.com/api/gateway');
 
             $gateway = Arr::get(json_decode($response->getBody(), true), 'url', $gateway);
         } catch (Exception $e) {

--- a/src/Exceptions/CouldNotSendNotification.php
+++ b/src/Exceptions/CouldNotSendNotification.php
@@ -32,7 +32,7 @@ class CouldNotSendNotification extends Exception
      *
      * @return static
      */
-    public static function serviceRespondedWithAnApiError(array $response, $code, $exception)
+    public static function serviceRespondedWithAnApiError(array $response, $code, $exception = null)
     {
         return new static("Discord responded with an API error: {$response['code']}: {$response['message']}", $code);
     }

--- a/tests/DiscordChannelTest.php
+++ b/tests/DiscordChannelTest.php
@@ -17,13 +17,13 @@ class DiscordChannelTest extends BaseTest
         $http = Mockery::mock(HttpClient::class);
         $http->shouldReceive('request')
             ->once()
-            ->with('POST', 'https://discordapp.com/api/channels/0123456789/messages', [
+            ->with('POST', 'https://discord.com/api/channels/0123456789/messages', [
                 'headers' => [
                     'Authorization' => 'Bot super-secret',
                 ],
                 'json' => ['content' => 'Hello, Discord!', 'embed' => [
                     'title' => 'Object Title',
-                    'url' => 'https://discordapp.com',
+                    'url' => 'https://discord.com',
                 ]],
             ])
             ->andReturn(new Response(200));
@@ -69,7 +69,7 @@ class TestNotification extends \Illuminate\Notifications\Notification
             ->body('Hello, Discord!')
             ->embed([
                 'title' => 'Object Title',
-                'url' => 'https://discordapp.com',
+                'url' => 'https://discord.com',
             ]);
     }
 }

--- a/tests/DiscordTest.php
+++ b/tests/DiscordTest.php
@@ -19,7 +19,7 @@ class DiscordTest extends BaseTest
         $http = Mockery::mock(HttpClient::class);
         $http->shouldReceive('request')
             ->once()
-            ->with('POST', 'https://discordapp.com/api/users/@me/channels', [
+            ->with('POST', 'https://discord.com/api/users/@me/channels', [
                 'headers' => [
                     'Authorization' => 'Bot super-secret',
                 ],
@@ -41,7 +41,7 @@ class DiscordTest extends BaseTest
         $http = Mockery::mock(HttpClient::class);
         $http->shouldReceive('request')
             ->once()
-            ->with('POST', 'https://discordapp.com/api/channels/some-channel-id/messages', [
+            ->with('POST', 'https://discord.com/api/channels/some-channel-id/messages', [
                 'headers' => [
                     'Authorization' => 'Bot super-secret',
                 ],
@@ -63,7 +63,7 @@ class DiscordTest extends BaseTest
         $http = Mockery::mock(HttpClient::class);
         $http->shouldReceive('request')
             ->once()
-            ->with('POST', 'https://discordapp.com/api/channels/some-channel-id/messages', [
+            ->with('POST', 'https://discord.com/api/channels/some-channel-id/messages', [
                 'headers' => [
                     'Authorization' => 'Bot super-secret',
                 ],
@@ -85,7 +85,7 @@ class DiscordTest extends BaseTest
         $http = Mockery::mock(HttpClient::class);
         $http->shouldReceive('request')
             ->once()
-            ->with('POST', 'https://discordapp.com/api/channels/some-channel-id/messages', [
+            ->with('POST', 'https://discord.com/api/channels/some-channel-id/messages', [
                 'headers' => [
                     'Authorization' => 'Bot super-secret',
                 ],
@@ -107,7 +107,7 @@ class DiscordTest extends BaseTest
         $http = Mockery::mock(HttpClient::class);
         $http->shouldReceive('request')
             ->once()
-            ->with('POST', 'https://discordapp.com/api/channels/some-channel-id/messages', [
+            ->with('POST', 'https://discord.com/api/channels/some-channel-id/messages', [
                 'headers' => [
                     'Authorization' => 'Bot super-secret',
                 ],

--- a/tests/SetupCommandTest.php
+++ b/tests/SetupCommandTest.php
@@ -10,6 +10,7 @@ use Illuminate\Contracts\Console\Kernel;
 use Mockery;
 use NotificationChannels\Discord\Commands\SetupCommand;
 use Orchestra\Testbench\TestCase as Orchestra;
+use Psr\Log\LoggerInterface;
 use WebSocket\Client;
 
 class SetupCommandTest extends Orchestra
@@ -35,7 +36,7 @@ class SetupCommandTest extends Orchestra
 
         $command->shouldReceive('confirm')->with('Is the bot already added to your server?')->once()->andReturn(false);
         $command->shouldReceive('ask')->with('What is your Discord app client ID?')->once()->andReturn('my-client-id');
-        $command->shouldReceive('warn')->with('Add the bot to your server by visiting this link: https://discordapp.com/oauth2/authorize?&client_id=my-client-id&scope=bot&permissions=0');
+        $command->shouldReceive('warn')->with('Add the bot to your server by visiting this link: https://discord.com/oauth2/authorize?&client_id=my-client-id&scope=bot&permissions=0');
         $command->shouldReceive('confirm')->with('Continue?', true)->once()->andReturn(false);
 
         $this->app[Kernel::class]->registerCommand($command);
@@ -59,7 +60,7 @@ class SetupCommandTest extends Orchestra
     {
         $http = Mockery::mock(HttpClient::class);
 
-        $http->shouldReceive('get')->with('https://discordapp.com/api/gateway')->once()->andReturn(new Response(200, [], json_encode(['url' => 'wss://test-gateway.discord.gg'])));
+        $http->shouldReceive('get')->with('https://discord.com/api/gateway')->once()->andReturn(new Response(200, [], json_encode(['url' => 'wss://test-gateway.discord.gg'])));
 
         $command = new SetupCommand($http, 'my-token');
 
@@ -73,7 +74,7 @@ class SetupCommandTest extends Orchestra
     {
         $http = Mockery::mock(HttpClient::class);
 
-        $http->shouldReceive('get')->with('https://discordapp.com/api/gateway')->once()->andThrow(new RequestException('Not found', Mockery::mock(Request::class), new Response(404, [], json_encode(['message' => 'Not found']))));
+        $http->shouldReceive('get')->with('https://discord.com/api/gateway')->once()->andThrow(new RequestException('Not found', Mockery::mock(Request::class), new Response(404, [], json_encode(['message' => 'Not found']))));
 
         $command = Mockery::mock(SetupCommand::class.'[warn]', [$http, 'my-token']);
 
@@ -136,7 +137,7 @@ class SetupCommandTest extends Orchestra
 
         $command->shouldReceive('confirm')->with('Is the bot already added to your server?')->once()->andReturn(false);
         $command->shouldReceive('ask')->with('What is your Discord app client ID?')->once()->andReturn('my-client-id');
-        $command->shouldReceive('warn')->with('Add the bot to your server by visiting this link: https://discordapp.com/oauth2/authorize?&client_id=my-client-id&scope=bot&permissions=0');
+        $command->shouldReceive('warn')->with('Add the bot to your server by visiting this link: https://discord.com/oauth2/authorize?&client_id=my-client-id&scope=bot&permissions=0');
         $command->shouldReceive('confirm')->with('Continue?', true)->once()->andReturn(true);
         $command->shouldReceive('warn')->with("Attempting to identify the bot with Discord's websocket gateway...")->once();
         $command->shouldReceive('getGateway')->once()->andReturn('wss://gateway.discord.gg');

--- a/tests/SetupCommandTest.php
+++ b/tests/SetupCommandTest.php
@@ -10,7 +10,6 @@ use Illuminate\Contracts\Console\Kernel;
 use Mockery;
 use NotificationChannels\Discord\Commands\SetupCommand;
 use Orchestra\Testbench\TestCase as Orchestra;
-use Psr\Log\LoggerInterface;
 use WebSocket\Client;
 
 class SetupCommandTest extends Orchestra


### PR DESCRIPTION
It looks like https://github.com/laravel-notification-channels/discord/pull/34 updated the domain, however there are other references to the old domain, so Travis builds have been [failing since then](https://travis-ci.org/github/laravel-notification-channels/discord/builds).

However, it seems like the underlying WebSocket PHP library now has a logger method, so some of the tests still fail with Mockery.