### PR TITLE
docs: fix build status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Latest Version on Packagist](https://img.shields.io/packagist/v/laravel-notification-channels/discord.svg?style=flat-square)](https://packagist.org/packages/laravel-notification-channels/discord)
 [![Software License](https://img.shields.io/badge/license-MIT-brightgreen.svg?style=flat-square)](LICENSE.md)
-[![Build Status](https://img.shields.io/github/workflow/status/laravel-notification-channels/discord/Tests.svg?style=flat-square)](https://github.com/laravel-notification-channels/discord/actions)
+[![Build Status](https://img.shields.io/github/workflow/status/laravel-notification-channels/discord/PHP.svg?style=flat-square)](https://github.com/laravel-notification-channels/discord/actions)
 [![StyleCI](https://styleci.io/repos/65772492/shield)](https://styleci.io/repos/65772492)
 [![Quality Score](https://img.shields.io/scrutinizer/g/laravel-notification-channels/discord.svg?style=flat-square)](https://scrutinizer-ci.com/g/laravel-notification-channels/discord)
 [![Code Coverage](https://img.shields.io/scrutinizer/coverage/g/laravel-notification-channels/discord/master.svg?style=flat-square)](https://scrutinizer-ci.com/g/laravel-notification-channels/discord/?branch=master)


### PR DESCRIPTION
I accidentally used Tests from my usual workflow badges, instead of PHP.