### PR TITLE
pass notification for routing

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -10,7 +10,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        php: ['7.2', '7.3', '7.4', '8.0']
+        php: ['7.2', '7.3', '7.4', '8.0', '8.1', '8.2']
         dependency-version: [prefer-lowest, prefer-stable]
 
     name: PHP ${{ matrix.php }} - OS ${{ matrix.os }} - ${{ matrix.dependency-version }}

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -11,7 +11,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         php: ['7.2', '7.3', '7.4', '8.0', '8.1', '8.2']
-        dependency-version: [prefer-lowest, prefer-stable]
+        dependency-version: [prefer-stable]
 
     name: PHP ${{ matrix.php }} - OS ${{ matrix.os }} - ${{ matrix.dependency-version }}
     steps:

--- a/src/DiscordChannel.php
+++ b/src/DiscordChannel.php
@@ -31,7 +31,7 @@ class DiscordChannel
      */
     public function send($notifiable, Notification $notification)
     {
-        if (! $channel = $notifiable->routeNotificationFor('discord')) {
+        if (! $channel = $notifiable->routeNotificationFor('discord', $notification)) {
             return;
         }
 

--- a/tests/SetupCommandTest.php
+++ b/tests/SetupCommandTest.php
@@ -49,7 +49,7 @@ class SetupCommandTest extends Orchestra
     {
         $command = new SetupCommand(new HttpClient, 'my-token');
 
-        $socket = $command->getSocket('my-gateway');
+        $socket = $command->getSocket('wss://gateway.discord.gg');
 
         $this->assertInstanceOf(Client::class, $socket);
     }
@@ -88,7 +88,7 @@ class SetupCommandTest extends Orchestra
     public function it_connects_to_the_discord_gateway()
     {
         $command = Mockery::mock(SetupCommand::class.'[getGateway,getSocket,confirm,ask,warn,info]', [new HttpClient, 'my-token']);
-        $socket = Mockery::mock(Client::class, ['wss://gateway.discord.gg']);
+        $socket = Mockery::mock(Client::class.'[send,receive]', ['wss://gateway.discord.gg']);
 
         $socket->shouldReceive('send')->with(json_encode([
             'op' => 2,
@@ -119,7 +119,7 @@ class SetupCommandTest extends Orchestra
     public function it_notifies_the_user_of_a_failed_identification_attempt()
     {
         $command = Mockery::mock(SetupCommand::class.'[getGateway,getSocket,confirm,ask,warn,error]', [new HttpClient, 'my-token']);
-        $socket = Mockery::mock(Client::class, ['wss://gateway.discord.gg']);
+        $socket = Mockery::mock(Client::class.'[send,receive]', ['wss://gateway.discord.gg']);
 
         $socket->shouldReceive('send')->with(json_encode([
             'op' => 2,


### PR DESCRIPTION
This PR adds the notification as an argument to the `routeNotificationFor()` call so that it can be used for routing - in case the notification holds the channel and not the notifiable or depending on notification type a different notifiable attribute is used.