### PR TITLE
Use phrity/websocket instead of textalk

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "illuminate/support": "^7.0 || ^8.0 || ^9.0 || ^10.0",
         "illuminate/queue": "^7.0 || ^8.0 || ^9.0 || ^10.0",
         "illuminate/console": "^7.0 || ^8.0 || ^9.0 || ^10.0",
-        "textalk/websocket": "^1.2"
+        "phrity/websocket": "^1.5"
     },
     "require-dev": {
         "mockery/mockery": "^1.3.3",


### PR DESCRIPTION
It seems like textalk/websocket is no longer maintained; https://github.com/Textalk/websocket-php/pull/191#issuecomment-1819905934 / https://github.com/Textalk/websocket-php/issues/183

I made a PR to their repo, since upgrading to `1.6.3` isn't possible because it requires `psr/http-message@^1.0`, many Laravel apps have 2.x installed.

Installing `phrity/websocket` version 2.x doesn't work yet, because it has breaking changes, I can work on that too, but I think requiring ^1.5 would be a good first step