### PR TITLE
fix for issue #68: send `embed` and `components` only if filled

### DIFF
--- a/src/DiscordChannel.php
+++ b/src/DiscordChannel.php
@@ -31,16 +31,24 @@ class DiscordChannel
      */
     public function send($notifiable, Notification $notification)
     {
-        if (! $channel = $notifiable->routeNotificationFor('discord', $notification)) {
+        if (!$channel = $notifiable->routeNotificationFor('discord', $notification)) {
             return;
         }
 
         $message = $notification->toDiscord($notifiable);
 
-        return $this->discord->send($channel, [
-            'content' => $message->body,
-            'embed' => $message->embed,
-            'components' => $message->components
-        ]);
+        $data = [
+            'content' => $message->body
+        ];
+
+        if (count($message->embed) > 0) {
+            $data['embeds'] = [$message->embed];
+        }
+
+        if (count($message->components) > 0) {
+            $data['components'] = $message->components;
+        }
+
+        return $this->discord->send($channel, $data);
     }
 }

--- a/src/DiscordChannel.php
+++ b/src/DiscordChannel.php
@@ -31,7 +31,7 @@ class DiscordChannel
      */
     public function send($notifiable, Notification $notification)
     {
-        if (!$channel = $notifiable->routeNotificationFor('discord', $notification)) {
+        if (! $channel = $notifiable->routeNotificationFor('discord', $notification)) {
             return;
         }
 

--- a/src/DiscordMessage.php
+++ b/src/DiscordMessage.php
@@ -62,9 +62,12 @@ class DiscordMessage
     }
 
     /**
-     * Set the embedded object.
+     * Set a single embedded object.
+     * 
+     * TODO: Refactor to enable multiple embeds.
+     * See https://discord.com/developers/docs/resources/channel#create-message
      *
-     * @param $embed
+     * @param array $embed
      *
      * @return $this
      */
@@ -78,7 +81,7 @@ class DiscordMessage
     /**
      * Set the components object.
      *
-     * @param $components
+     * @param array $components
      *
      * @return $this
      */

--- a/tests/DiscordChannelTest.php
+++ b/tests/DiscordChannelTest.php
@@ -22,18 +22,22 @@ class DiscordChannelTest extends BaseTest
                     'Authorization' => 'Bot super-secret',
                 ],
                 'json' => [
-                    'content' => 'Hello, Discord!', 'embed' => [
-                        'title' => 'Object Title',
-                        'url' => 'https://discord.com',
-                    ], "components" => [
+                    'content' => 'Hello, Discord!',
+                    'embeds' => [
+                        0 => [
+                            'title' => 'Object Title',
+                            'url' => 'https://discord.com',
+                        ]
+                    ],
+                    'components' => [
                         [
-                            "type" => 1,
-                            "components" => [
+                            'type' => 1,
+                            'components' => [
                                 [
-                                    "type" => 2,
-                                    "label" => "Test",
-                                    "style" => 1,
-                                    "custom_id" => "primary"
+                                    'type' => 2,
+                                    'label' => 'Test',
+                                    'style' => 1,
+                                    'custom_id' => 'primary'
                                 ]
                             ]
                         ]
@@ -84,7 +88,8 @@ class TestNotification extends \Illuminate\Notifications\Notification
             ->embed([
                 'title' => 'Object Title',
                 'url' => 'https://discord.com',
-            ])->components([
+            ])
+            ->components([
                 [
                     "type" => 1,
                     "components" => [


### PR DESCRIPTION
note: discord have no documented `embed` attribute, it is called `embeds` and should be send as an array. Maybe in the older days it was called `embed`. I go with the current documentation here, see https://discord.com/developers/docs/resources/channel#create-message