### PR TITLE
PHP: added 8.3, removed 7.x

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -10,7 +10,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        php: ['7.2', '7.3', '7.4', '8.0', '8.1', '8.2']
+        php: ['8.0', '8.1', '8.2', '8.3']
         dependency-version: [prefer-stable]
 
     name: PHP ${{ matrix.php }} - OS ${{ matrix.os }} - ${{ matrix.dependency-version }}

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         }
     ],
     "require": {
-        "php": "^7.2|^8.0",
+        "php": "^8.0",
         "ext-json": "*",
         "guzzlehttp/guzzle": "^6.3 || ^7.0",
         "illuminate/notifications": "^7.0 || ^8.0 || ^9.0 || ^10.0",


### PR DESCRIPTION
PHP 7.x are now end of life and I bumped a minimum version up to 8.0. I have also made several changes to the Workflow: added 8.3 and removed 7.x. Now tests pass.

@atymic, can you please take a look? Thanks!